### PR TITLE
Fix issue where content cannot be specified. (addresses #93)

### DIFF
--- a/makerom/user_settings.c
+++ b/makerom/user_settings.c
@@ -40,6 +40,11 @@ int ParseArgs(int argc, char *argv[], user_settings *set)
 		fprintf(stderr, "[SETTING ERROR] Not Enough Memory\n");
 		return USR_MEM_ERROR;
 	}
+	// Initialise Content Path Ptrs to NULL
+	for (size_t i = 0; i < CIA_MAX_CONTENT; i++)
+	{
+		set->common.contentPath[i] = NULL;
+	}
 
 	// Initialise Keys
 	InitKeys(&set->common.keys);

--- a/makerom/user_settings.c
+++ b/makerom/user_settings.c
@@ -907,7 +907,7 @@ void PrintNoNeedParam(char *arg)
 
 void DisplayBanner(void)
 {
-	printf("CTR MAKEROM v0.17 (C) 3DSGuy 2020\n");
+	printf("CTR MAKEROM v0.17.1 (C) 3DSGuy 2020\n");
 	printf("Built: %s %s\n\n", __TIME__, __DATE__);
 }
 


### PR DESCRIPTION
This attempts to fix issue (#93)  reported by @TimmSkiller where they were unable to specify content 0, with an error message saying it had already been specified.

**Error:** `[SETTING ERROR] Content 0 is already specified`