### PR TITLE
Add support for custom decrypted TitleKey

### DIFF
--- a/makerom/cia.c
+++ b/makerom/cia.c
@@ -184,6 +184,12 @@ int GetSettingsFromUsrset(cia_settings *ciaset, user_settings *usrset)
 	
 	if(usrset->cia.randomTitleKey)
 		rndset(ciaset->common.titleKey,AES_128_KEY_SIZE);
+	else if(usrset->cia.titleKey){
+    for (size_t count = 0; count < sizeof(ciaset->common.titleKey)/sizeof(ciaset->common.titleKey[0]); count++) {
+      sscanf(usrset->cia.titleKey, "%2hhx", &ciaset->common.titleKey[count]);
+      usrset->cia.titleKey += 2;
+    }
+	}
 	else
 		clrmem(ciaset->common.titleKey,AES_128_KEY_SIZE);
 

--- a/makerom/cia.c
+++ b/makerom/cia.c
@@ -160,7 +160,7 @@ int GetSettingsFromUsrset(cia_settings *ciaset, user_settings *usrset)
 	ciaset->verbose = usrset->common.verbose;
 	
 	ciaset->tmd.titleType = TYPE_CTR;
-	ciaset->content.encryptCia = usrset->common.rsfSet.Option.EnableCrypt;
+	ciaset->content.encryptCia = usrset->common.rsfSet.Option.EnableCrypt || usrset->cia.titleKey != NULL;
 	ciaset->content.IsDlc = usrset->cia.DlcContent;
 	if(ciaset->keys->aes.commonKey[ciaset->keys->aes.currentCommonKey] == NULL && ciaset->content.encryptCia){
 		fprintf(stderr,"[CIA WARNING] Common Key could not be loaded, CIA will not be encrypted\n");
@@ -185,10 +185,10 @@ int GetSettingsFromUsrset(cia_settings *ciaset, user_settings *usrset)
 	if(usrset->cia.randomTitleKey)
 		rndset(ciaset->common.titleKey,AES_128_KEY_SIZE);
 	else if(usrset->cia.titleKey){
-    for (size_t count = 0; count < sizeof(ciaset->common.titleKey)/sizeof(ciaset->common.titleKey[0]); count++) {
-      sscanf(usrset->cia.titleKey, "%2hhx", &ciaset->common.titleKey[count]);
-      usrset->cia.titleKey += 2;
-    }
+		for (size_t count = 0; count < sizeof(ciaset->common.titleKey)/sizeof(ciaset->common.titleKey[0]); count++) {
+			sscanf(usrset->cia.titleKey, "%2hhx", &ciaset->common.titleKey[count]);
+			usrset->cia.titleKey += 2;
+		}
 	}
 	else
 		clrmem(ciaset->common.titleKey,AES_128_KEY_SIZE);

--- a/makerom/tik.c
+++ b/makerom/tik.c
@@ -65,7 +65,7 @@ void SetupTicketHeader(tik_hdr *hdr, cia_settings *ciaset)
 	SetLimits(hdr,ciaset);
 	
 	// Crypt TitleKey
-	if(ciaset->content.encryptCia)
+	if(ciaset->content.encryptCia || ciaset->common.titleKey)
 		CryptTitleKey(ciaset->common.titleKey, hdr->encryptedTitleKey, hdr->titleId, ciaset->keys, ENC);
 	else
 		rndset(hdr->encryptedTitleKey,AES_128_KEY_SIZE);

--- a/makerom/tik.c
+++ b/makerom/tik.c
@@ -65,7 +65,7 @@ void SetupTicketHeader(tik_hdr *hdr, cia_settings *ciaset)
 	SetLimits(hdr,ciaset);
 	
 	// Crypt TitleKey
-	if(ciaset->content.encryptCia || ciaset->common.titleKey)
+	if(ciaset->content.encryptCia)
 		CryptTitleKey(ciaset->common.titleKey, hdr->encryptedTitleKey, hdr->titleId, ciaset->keys, ENC);
 	else
 		rndset(hdr->encryptedTitleKey,AES_128_KEY_SIZE);

--- a/makerom/user_settings.c
+++ b/makerom/user_settings.c
@@ -559,6 +559,14 @@ int SetArgument(int argc, int i, char *argv[], user_settings *set)
 		set->cia.randomTitleKey = true;
 		return 1;
 	}
+	else if (strcmp(argv[i], "-titlekey") == 0) {
+		if (ParamNum != 1) {
+			PrintArgReqParam(argv[i], 1);
+			return USR_ARG_REQ_PARAM;
+		}
+    set->cia.titleKey = argv[i + 1];
+		return 2;
+	}
 	else if (strcmp(argv[i], "-dlc") == 0) {
 		if (ParamNum) {
 			PrintNoNeedParam(argv[i]);
@@ -990,6 +998,7 @@ void DisplayExtendedHelp(char *app_name)
 	printf(" -dver          <version>           Data-title version\n");
 	printf(" -deviceid      <hex id>            3DS unique device ID\n");
 	printf(" -esaccid       <hex id>            e-Shop account ID\n");
+	printf(" -titlekey      <titlekey>          Specify decrypted title key\n");
 	printf(" -rand                              Use a random title key\n");
 	printf(" -dlc                               Create DLC CIA\n");
 	printf(" -srl           <srl file>          Package a TWL SRL in a CIA\n");

--- a/makerom/user_settings.c
+++ b/makerom/user_settings.c
@@ -564,7 +564,7 @@ int SetArgument(int argc, int i, char *argv[], user_settings *set)
 			PrintArgReqParam(argv[i], 1);
 			return USR_ARG_REQ_PARAM;
 		}
-    set->cia.titleKey = argv[i + 1];
+		set->cia.titleKey = argv[i + 1];
 		return 2;
 	}
 	else if (strcmp(argv[i], "-dlc") == 0) {
@@ -998,7 +998,7 @@ void DisplayExtendedHelp(char *app_name)
 	printf(" -dver          <version>           Data-title version\n");
 	printf(" -deviceid      <hex id>            3DS unique device ID\n");
 	printf(" -esaccid       <hex id>            e-Shop account ID\n");
-	printf(" -titlekey      <titlekey>          Specify decrypted title key\n");
+	printf(" -titlekey      <titlekey>          Specify decrypted title key (Overrides \"EnableCrypt\" in RSF to true)\n");
 	printf(" -rand                              Use a random title key\n");
 	printf(" -dlc                               Create DLC CIA\n");
 	printf(" -srl           <srl file>          Package a TWL SRL in a CIA\n");

--- a/makerom/user_settings.h
+++ b/makerom/user_settings.h
@@ -284,6 +284,7 @@ typedef struct
 	
 	struct{
 		bool randomTitleKey;
+		char *titleKey;
 		bool encryptCia;
 		bool DlcContent;
 		bool includeUpdateNcch;


### PR DESCRIPTION
I've added the `-titlekey` option, so users can specify a decrypted TitleKey to use when encrypting a CIA.