### PR TITLE
Fix issue where SeedDB would not import correctly.

### DIFF
--- a/ctrtool/src/KeyBag.cpp
+++ b/ctrtool/src/KeyBag.cpp
@@ -921,7 +921,7 @@ void ctrtool::KeyBagInitializer::importSeedDb(const std::shared_ptr<tc::io::ISou
 	// import entries
 	for (size_t i = 0; i < n_entries; i++)
 	{
-		seed_db.insert(std::pair<byte_t, KeyBag::Aes128Key>(entry[i].title_id.unwrap(), entry[i].seed));
+		seed_db.insert(std::pair<uint64_t, KeyBag::Aes128Key>(entry[i].title_id.unwrap(), entry[i].seed));
 	}
 }
 


### PR DESCRIPTION
@[Dimensional](https://github.com/Dimensional) reported a bug #111 where the SeedDB would not import correctly (when using `--seeddb`) and was forced to extract the seed and use `--seed` instead.

This should fix that bug.