### PR TITLE
Fix issue where compressed .code partition wasn't being decompressed.

### DIFF
--- a/ctrtool/src/NcchProcess.cpp
+++ b/ctrtool/src/NcchProcess.cpp
@@ -790,6 +790,17 @@ void ctrtool::NcchProcess::processRegions()
 	}
 	if (mRegionInfo[NcchRegion_ExeFs].size != 0 && mRegionInfo[NcchRegion_ExeFs].ready_stream != nullptr)
 	{
+		// prior to reading exefs, check compressed flag in exheader
+		if (mRegionInfo[NcchRegion_ExHeader].size > 0 && mRegionInfo[NcchRegion_ExHeader].ready_stream != nullptr)
+		{
+			// import exheader			
+			ntd::n3ds::ExtendedHeader exheader;
+			mRegionInfo[NcchRegion_ExHeader].ready_stream->seek(0, tc::io::SeekOrigin::Begin);
+			mRegionInfo[NcchRegion_ExHeader].ready_stream->read((byte_t*)&exheader, sizeof(ntd::n3ds::ExtendedHeader));
+
+			mDecompressExeFsCode = exheader.system_control_info.flags.bitarray.test(ntd::n3ds::SystemControlInfo::Flags_CompressExefsPartition0);
+		}
+
 		ctrtool::ExeFsProcess proc;
 		proc.setInputStream(mRegionInfo[NcchRegion_ExeFs].ready_stream);
 		proc.setCliOutputMode(mRegionOpt[NcchRegion_ExeFs].show_info, mRegionOpt[NcchRegion_ExeFs].show_fs);

--- a/ctrtool/src/version.h
+++ b/ctrtool/src/version.h
@@ -3,5 +3,5 @@
 #define BIN_NAME	"ctrtool"
 #define VER_MAJOR	1
 #define VER_MINOR	0
-#define VER_PATCH	2
+#define VER_PATCH	3
 #define AUTHORS		"jakcron"


### PR DESCRIPTION
### Bug
ExHeader SystemControlInfo flag `Flags_CompressExefsPartition0` was not being processed prior to extracting ExeFs.
### Solution
* Read the flag and honour its value.
* Also bumped the patch version
