### PR TITLE
Fix bug where CCI CryptoType 1-2 weren't processed properly.

### DIFF
--- a/ctrtool/deps/libnintendo-n3ds/include/ntd/n3ds/cci.h
+++ b/ctrtool/deps/libnintendo-n3ds/include/ntd/n3ds/cci.h
@@ -167,7 +167,9 @@ struct CciHeader
 
 	enum CryptoType
 	{
-		CryptoType_Secure = 0, // Secure initial data key (keyX bootrom, keyY initial data seed) (used in production ROMs)
+		CryptoType_Secure0 = 0, // Secure initial data key (keyX bootrom, keyY initial data seed) (used in production ROMs)
+		CryptoType_Secure1 = 1, // Secure initial data key (keyX bootrom, keyY initial data seed) (used in production ROMs)
+		CryptoType_Secure2 = 2, // Secure initial data key (keyX bootrom, keyY initial data seed) (used in production ROMs)
 		CryptoType_FixedKey = 3, // Zeros initial data key (used in non-HSM enviroments like development)
 	};
 

--- a/ctrtool/src/CciProcess.cpp
+++ b/ctrtool/src/CciProcess.cpp
@@ -171,8 +171,10 @@ void ctrtool::CciProcess::importHeader()
 	ctrtool::KeyBag::Aes128Key initial_data_key;
 	bool initial_data_key_available = false;
 
-	// crypto_type 0 is the normal "secure" initial data key 
-	if (mHeader.card_info.flag.crypto_type == ntd::n3ds::CciHeader::CryptoType_Secure)
+	// crypto_type 0-2 is the normal "secure" initial data key 
+	if (mHeader.card_info.flag.crypto_type == ntd::n3ds::CciHeader::CryptoType_Secure0 ||
+		mHeader.card_info.flag.crypto_type == ntd::n3ds::CciHeader::CryptoType_Secure1 ||
+		mHeader.card_info.flag.crypto_type == ntd::n3ds::CciHeader::CryptoType_Secure2)
 	{
 		if (mKeyBag.brom_static_key_x.find(mKeyBag.KEYSLOT_INITIAL_DATA) != mKeyBag.brom_static_key_x.end())
 		{	
@@ -530,8 +532,14 @@ std::string ctrtool::CciProcess::getCryptoTypeString(byte_t crypto_type)
 
 	switch(crypto_type)
 	{
-		case ntd::n3ds::CciHeader::CryptoType_Secure :
-			ret_str = "Secure";
+		case ntd::n3ds::CciHeader::CryptoType_Secure0 :
+			ret_str = "Secure0";
+			break;
+		case ntd::n3ds::CciHeader::CryptoType_Secure1 :
+			ret_str = "Secure1";
+			break;
+		case ntd::n3ds::CciHeader::CryptoType_Secure2 :
+			ret_str = "Secure2";
 			break;
 		case ntd::n3ds::CciHeader::CryptoType_FixedKey :
 			ret_str = "FixedKey";

--- a/ctrtool/src/version.h
+++ b/ctrtool/src/version.h
@@ -3,5 +3,5 @@
 #define BIN_NAME	"ctrtool"
 #define VER_MAJOR	1
 #define VER_MINOR	0
-#define VER_PATCH	3
+#define VER_PATCH	4
 #define AUTHORS		"jakcron"


### PR DESCRIPTION
This addresses #116 

It was pointed out that CCIs released 2015 or later use a CryptoType 1, instead of 0. But the initial_data keyX used is the same. So CciProcess was updated to support support all 4 CryptoType values.

* Also bumped version to 1.0.4