### PR TITLE
[MakeROM] Fix InitialData generation bugs

### DIFF
--- a/makerom/src/cardinfo.c
+++ b/makerom/src/cardinfo.c
@@ -135,10 +135,15 @@ int SetCardInfoBitmask(cardinfo_hdr *hdr, cci_settings *set)
 	
 	str = set->rsf->CardInfo.CryptoType;
 	if(!str) {
-		if(set->options.useExternalSdkCardInfo)
-			bitmask |= (3 << 6);
-		else
-			bitmask |= 0;
+		u32 val = 0;
+		if(set->keys->keyset == pki_DEVELOPMENT) {
+			val = 3;
+		}
+		else{
+			val = 0;
+		}
+
+		bitmask |= (val << 6);
 	}
 	else{
 		int val = strtol(str,NULL,10);

--- a/makerom/src/keyset.c
+++ b/makerom/src/keyset.c
@@ -150,7 +150,7 @@ int LoadKeysFromResources(keys_struct *keys)
 			SetNcchKeyX(keys, prod_unfixed_ncch_keyX[i],i);
 		
 		// CCI
-		SetCciInitialDataKeyX(keys, dev_initial_data_keyx);
+		SetCciInitialDataKeyX(keys, prod_initial_data_keyx);
 
 		/* RSA Keys */
 		// CIA

--- a/makerom/src/ncsd.c
+++ b/makerom/src/ncsd.c
@@ -581,7 +581,7 @@ int GenCciHdr(cci_settings *set)
 	// Sign Header
 	if (Rsa2048Key_CanSign(&set->keys->rsa.cciCfa) == false)
 	{
-		printf("[NCSD WARNING] Failed to sign header\n");
+		printf("[NCSD WARNING] Failed to sign header (key was incomplete)\n");
 		memset(hdr->signature, 0xFF, 0x100);
 		return 0;
 	}

--- a/makerom/src/user_settings.c
+++ b/makerom/src/user_settings.c
@@ -910,7 +910,7 @@ void PrintNoNeedParam(char *arg)
 
 void DisplayBanner(void)
 {
-	printf("CTR MAKEROM v0.18.1 (C) 3DSGuy 2022\n");
+	printf("CTR MAKEROM v0.18.2 (C) 3DSGuy 2022\n");
 	printf("Built: %s %s\n\n", __TIME__, __DATE__);
 }
 


### PR DESCRIPTION
# About
MakeROM v0.18.1 did implement InitialData generation. However there were two bugs:
* Production InitialData KeyX wasn't initialized correctly
* If the target is `development`, the correct CCI crypto type isn't automatiically selected.

# Changes
* Bump version to v0.18.2
* [BugFix] Correctly initialize prod InitialData KeyX.
* [BugFix] Properly select CCI CryptoType when not manually specified.