### PR TITLE
Update makefiles to address impl func warnings on linux.

### DIFF
--- a/makerom/deps/libblz/makefile
+++ b/makerom/deps/libblz/makefile
@@ -1,6 +1,6 @@
 # C++/C Recursive Project Makefile 
 # (c) Jack
-# Version 7 (20220416)
+# Version 8 (20220420)
 
 # Project Name
 PROJECT_NAME = libblz
@@ -75,6 +75,7 @@ ifeq ($(PROJECT_PLATFORM), WIN32)
 	# Windows Flags/Libs
 	CC = x86_64-w64-mingw32-gcc
 	CXX = x86_64-w64-mingw32-g++
+	DEFINEFLAGS =
 	WARNFLAGS = -Wall -Wno-unused-value -Wno-unused-but-set-variable
 	ARCHFLAGS =
 	INC +=
@@ -84,6 +85,7 @@ else ifeq ($(PROJECT_PLATFORM), GNU)
 	# GNU/Linux Flags/Libs
 	#CC = 
 	#CXX =
+	DEFINEFLAGS =
 	WARNFLAGS = -Wall -Wno-unused-value -Wno-unused-but-set-variable
 	ARCHFLAGS =
 	INC +=
@@ -93,6 +95,7 @@ else ifeq ($(PROJECT_PLATFORM), MACOS)
 	# MacOS Flags/Libs
 	#CC = 
 	#CXX =
+	DEFINEFLAGS =
 	WARNFLAGS = -Wall -Wno-unused-value -Wno-unused-private-field
 	ARCHFLAGS = -arch $(PROJECT_PLATFORM_ARCH)
 	INC +=
@@ -101,8 +104,8 @@ else ifeq ($(PROJECT_PLATFORM), MACOS)
 endif
 
 # Compiler Flags
-CXXFLAGS = -std=c++11 $(INC) $(WARNFLAGS) $(ARCHFLAGS) -fPIC
-CFLAGS = -std=c11 $(INC) $(WARNFLAGS) $(ARCHFLAGS) -fPIC
+CXXFLAGS = -std=c++11 $(INC) $(DEFINEFLAGS) $(WARNFLAGS) $(ARCHFLAGS) -fPIC
+CFLAGS = -std=c11 $(INC) $(DEFINEFLAGS) $(WARNFLAGS) $(ARCHFLAGS) -fPIC
 
 # Object Files
 SRC_OBJ = $(foreach dir,$(PROJECT_SRC_SUBDIRS),$(subst .cpp,.o,$(wildcard $(dir)/*.cpp))) $(foreach dir,$(PROJECT_SRC_SUBDIRS),$(subst .cc,.o,$(wildcard $(dir)/*.cc))) $(foreach dir,$(PROJECT_SRC_SUBDIRS),$(subst .c,.o,$(wildcard $(dir)/*.c)))

--- a/makerom/deps/libyaml/makefile
+++ b/makerom/deps/libyaml/makefile
@@ -85,7 +85,7 @@ else ifeq ($(PROJECT_PLATFORM), GNU)
 	# GNU/Linux Flags/Libs
 	#CC = 
 	#CXX =
-	DEFINEFLAGS = -D_BSD_SOURCE
+	DEFINEFLAGS = -D_DEFAULT_SOURCE
 	WARNFLAGS = -Wall -Wno-unused-value -Wno-unused-but-set-variable
 	ARCHFLAGS =
 	INC +=

--- a/makerom/deps/libyaml/makefile
+++ b/makerom/deps/libyaml/makefile
@@ -1,6 +1,6 @@
 # C++/C Recursive Project Makefile 
 # (c) Jack
-# Version 7 (20220416)
+# Version 8 (20220420)
 
 # Project Name
 PROJECT_NAME = libyaml
@@ -75,6 +75,7 @@ ifeq ($(PROJECT_PLATFORM), WIN32)
 	# Windows Flags/Libs
 	CC = x86_64-w64-mingw32-gcc
 	CXX = x86_64-w64-mingw32-g++
+	DEFINEFLAGS =
 	WARNFLAGS = -Wall -Wno-unused-value -Wno-unused-but-set-variable
 	ARCHFLAGS =
 	INC +=
@@ -84,6 +85,7 @@ else ifeq ($(PROJECT_PLATFORM), GNU)
 	# GNU/Linux Flags/Libs
 	#CC = 
 	#CXX =
+	DEFINEFLAGS = -D_BSD_SOURCE
 	WARNFLAGS = -Wall -Wno-unused-value -Wno-unused-but-set-variable
 	ARCHFLAGS =
 	INC +=
@@ -93,6 +95,7 @@ else ifeq ($(PROJECT_PLATFORM), MACOS)
 	# MacOS Flags/Libs
 	#CC = 
 	#CXX =
+	DEFINEFLAGS =
 	WARNFLAGS = -Wall -Wno-unused-value -Wno-unused-private-field
 	ARCHFLAGS = -arch $(PROJECT_PLATFORM_ARCH)
 	INC +=
@@ -101,8 +104,8 @@ else ifeq ($(PROJECT_PLATFORM), MACOS)
 endif
 
 # Compiler Flags
-CXXFLAGS = -std=c++11 $(INC) $(WARNFLAGS) $(ARCHFLAGS) -fPIC
-CFLAGS = -std=c11 $(INC) $(WARNFLAGS) $(ARCHFLAGS) -fPIC
+CXXFLAGS = -std=c++11 $(INC) $(DEFINEFLAGS) $(WARNFLAGS) $(ARCHFLAGS) -fPIC
+CFLAGS = -std=c11 $(INC) $(DEFINEFLAGS) $(WARNFLAGS) $(ARCHFLAGS) -fPIC
 
 # Object Files
 SRC_OBJ = $(foreach dir,$(PROJECT_SRC_SUBDIRS),$(subst .cpp,.o,$(wildcard $(dir)/*.cpp))) $(foreach dir,$(PROJECT_SRC_SUBDIRS),$(subst .cc,.o,$(wildcard $(dir)/*.cc))) $(foreach dir,$(PROJECT_SRC_SUBDIRS),$(subst .c,.o,$(wildcard $(dir)/*.c)))

--- a/makerom/deps/libyaml/makefile
+++ b/makerom/deps/libyaml/makefile
@@ -85,7 +85,7 @@ else ifeq ($(PROJECT_PLATFORM), GNU)
 	# GNU/Linux Flags/Libs
 	#CC = 
 	#CXX =
-	DEFINEFLAGS = -D_DEFAULT_SOURCE
+	DEFINEFLAGS = -D_GNU_SOURCE
 	WARNFLAGS = -Wall -Wno-unused-value -Wno-unused-but-set-variable
 	ARCHFLAGS =
 	INC +=

--- a/makerom/makefile
+++ b/makerom/makefile
@@ -85,7 +85,7 @@ else ifeq ($(PROJECT_PLATFORM), GNU)
 	# GNU/Linux Flags/Libs
 	#CC = 
 	#CXX =
-	DEFINEFLAGS = -D_BSD_SOURCE
+	DEFINEFLAGS = -D_DEFAULT_SOURCE
 	WARNFLAGS = -Wall -Wno-unused-value -Wno-unused-but-set-variable
 	ARCHFLAGS =
 	INC +=

--- a/makerom/makefile
+++ b/makerom/makefile
@@ -1,6 +1,6 @@
 # C++/C Recursive Project Makefile 
 # (c) Jack
-# Version 7 (20220416)
+# Version 8 (20220420)
 
 # Project Name
 PROJECT_NAME = makerom
@@ -75,6 +75,7 @@ ifeq ($(PROJECT_PLATFORM), WIN32)
 	# Windows Flags/Libs
 	CC = x86_64-w64-mingw32-gcc
 	CXX = x86_64-w64-mingw32-g++
+	DEFINEFLAGS =
 	WARNFLAGS = -Wall -Wno-unused-value -Wno-unused-but-set-variable
 	ARCHFLAGS =
 	INC +=
@@ -84,6 +85,7 @@ else ifeq ($(PROJECT_PLATFORM), GNU)
 	# GNU/Linux Flags/Libs
 	#CC = 
 	#CXX =
+	DEFINEFLAGS = -D_BSD_SOURCE
 	WARNFLAGS = -Wall -Wno-unused-value -Wno-unused-but-set-variable
 	ARCHFLAGS =
 	INC +=
@@ -93,6 +95,7 @@ else ifeq ($(PROJECT_PLATFORM), MACOS)
 	# MacOS Flags/Libs
 	#CC = 
 	#CXX =
+	DEFINEFLAGS =
 	WARNFLAGS = -Wall -Wno-unused-value -Wno-unused-private-field
 	ARCHFLAGS = -arch $(PROJECT_PLATFORM_ARCH)
 	INC +=
@@ -101,8 +104,8 @@ else ifeq ($(PROJECT_PLATFORM), MACOS)
 endif
 
 # Compiler Flags
-CXXFLAGS = -std=c++11 $(INC) $(WARNFLAGS) $(ARCHFLAGS) -fPIC
-CFLAGS = -std=c11 $(INC) $(WARNFLAGS) $(ARCHFLAGS) -fPIC
+CXXFLAGS = -std=c++11 $(INC) $(DEFINEFLAGS) $(WARNFLAGS) $(ARCHFLAGS) -fPIC
+CFLAGS = -std=c11 $(INC) $(DEFINEFLAGS) $(WARNFLAGS) $(ARCHFLAGS) -fPIC
 
 # Object Files
 SRC_OBJ = $(foreach dir,$(PROJECT_SRC_SUBDIRS),$(subst .cpp,.o,$(wildcard $(dir)/*.cpp))) $(foreach dir,$(PROJECT_SRC_SUBDIRS),$(subst .cc,.o,$(wildcard $(dir)/*.cc))) $(foreach dir,$(PROJECT_SRC_SUBDIRS),$(subst .c,.o,$(wildcard $(dir)/*.c)))

--- a/makerom/makefile
+++ b/makerom/makefile
@@ -85,7 +85,7 @@ else ifeq ($(PROJECT_PLATFORM), GNU)
 	# GNU/Linux Flags/Libs
 	#CC = 
 	#CXX =
-	DEFINEFLAGS = -D_DEFAULT_SOURCE
+	DEFINEFLAGS = -D_GNU_SOURCE
 	WARNFLAGS = -Wall -Wno-unused-value -Wno-unused-but-set-variable
 	ARCHFLAGS =
 	INC +=

--- a/makerom/src/user_settings.c
+++ b/makerom/src/user_settings.c
@@ -910,7 +910,7 @@ void PrintNoNeedParam(char *arg)
 
 void DisplayBanner(void)
 {
-	printf("CTR MAKEROM v0.18.2 (C) 3DSGuy 2022\n");
+	printf("CTR MAKEROM v0.18.3 (C) 3DSGuy 2022\n");
 	printf("Built: %s %s\n\n", __TIME__, __DATE__);
 }
 


### PR DESCRIPTION
# About
This addresses issue #122 where functions were not defined properly on Linux targets when building MakeROM (causing segfaults):
* `strdup()` in makerom/deps/libyaml/src/api.c
* `truncate()` in makerom/src/utils.c

# Changes
* Bump version to v0.18.3
* [BuildSystem] `makefile` for makerom and libyaml updated to define `-D_GNU_SOURCE` for linux builds.