### PR TITLE
[CTRTool] Honour plain flag when processing CIA files.

### DIFF
--- a/ctrtool/build/visualstudio/CTRTool/CTRTool.vcxproj
+++ b/ctrtool/build/visualstudio/CTRTool/CTRTool.vcxproj
@@ -153,6 +153,7 @@
     <ClInclude Include="..\..\..\src\types.h" />
     <ClInclude Include="..\..\..\src\TikProcess.h" />
     <ClInclude Include="..\..\..\src\TmdProcess.h" />
+    <ClInclude Include="..\..\..\src\util.h" />
     <ClInclude Include="..\..\..\src\version.h" />
   </ItemGroup>
   <ItemGroup>
@@ -172,6 +173,7 @@
     <ClCompile Include="..\..\..\src\Settings.cpp" />
     <ClCompile Include="..\..\..\src\TikProcess.cpp" />
     <ClCompile Include="..\..\..\src\TmdProcess.cpp" />
+    <ClCompile Include="..\..\..\src\util.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\deps\libfmt\build\visualstudio\libfmt\libfmt.vcxproj">

--- a/ctrtool/build/visualstudio/CTRTool/CTRTool.vcxproj.filters
+++ b/ctrtool/build/visualstudio/CTRTool/CTRTool.vcxproj.filters
@@ -66,6 +66,9 @@
     <ClInclude Include="..\..\..\src\TmdProcess.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\src\util.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\..\src\version.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -117,6 +120,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\src\TmdProcess.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\util.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/ctrtool/src/CiaProcess.h
+++ b/ctrtool/src/CiaProcess.h
@@ -46,6 +46,7 @@ private:
 	bool mShowHeaderInfo;
 	bool mVerbose;
 	bool mVerify;
+	bool mPlain;
 	tc::Optional<tc::io::Path> mCertExtractPath;
 	tc::Optional<tc::io::Path> mTikExtractPath;
 	tc::Optional<tc::io::Path> mTmdExtractPath;
@@ -108,7 +109,6 @@ private:
 	void verifyContent();
 	void printHeader();
 	void extractCia();
-	void copyStream(const std::shared_ptr<tc::io::IStream>& in, const std::shared_ptr<tc::io::IStream>& out);
 	void processContent();
 
 	void createContentIv(std::array<byte_t, 16>& content_iv, uint16_t index);

--- a/ctrtool/src/util.cpp
+++ b/ctrtool/src/util.cpp
@@ -1,0 +1,52 @@
+#include "util.h"
+
+#include <tc/io/FileStream.h>
+#include <tc/io/SubStream.h>
+#include <tc/io/IOUtil.h>
+
+void ctrtool::writeSubStreamToFile(const std::shared_ptr<tc::io::IStream>& in_stream, int64_t offset, int64_t length, const tc::io::Path& out_path, tc::ByteData& cache)
+{
+	writeStreamToStream(std::make_shared<tc::io::SubStream>(tc::io::SubStream(in_stream, offset, length)), std::make_shared<tc::io::FileStream>(tc::io::FileStream(out_path, tc::io::FileMode::Create, tc::io::FileAccess::Write)), cache);
+}
+
+void ctrtool::writeSubStreamToFile(const std::shared_ptr<tc::io::IStream>& in_stream, int64_t offset, int64_t length, const tc::io::Path& out_path, size_t cache_size)
+{
+	writeStreamToStream(std::make_shared<tc::io::SubStream>(tc::io::SubStream(in_stream, offset, length)), std::make_shared<tc::io::FileStream>(tc::io::FileStream(out_path, tc::io::FileMode::Create, tc::io::FileAccess::Write)), cache_size);
+}
+
+void ctrtool::writeStreamToFile(const std::shared_ptr<tc::io::IStream>& in_stream, const tc::io::Path& out_path, tc::ByteData& cache)
+{
+	writeStreamToStream(in_stream, std::make_shared<tc::io::FileStream>(tc::io::FileStream(out_path, tc::io::FileMode::Create, tc::io::FileAccess::Write)), cache);
+}
+
+void ctrtool::writeStreamToFile(const std::shared_ptr<tc::io::IStream>& in_stream, const tc::io::Path& out_path, size_t cache_size)
+{
+	writeStreamToStream(in_stream, std::make_shared<tc::io::FileStream>(tc::io::FileStream(out_path, tc::io::FileMode::Create, tc::io::FileAccess::Write)), cache_size);
+}
+
+void ctrtool::writeStreamToStream(const std::shared_ptr<tc::io::IStream>& in_stream, const std::shared_ptr<tc::io::IStream>& out_stream, tc::ByteData& cache)
+{
+	// iterate thru child files
+	size_t cache_read_len;
+	
+	in_stream->seek(0, tc::io::SeekOrigin::Begin);
+	out_stream->seek(0, tc::io::SeekOrigin::Begin);
+	for (int64_t remaining_data = in_stream->length(); remaining_data > 0;)
+	{
+		cache_read_len = in_stream->read(cache.data(), cache.size());
+		if (cache_read_len == 0)
+		{
+			throw tc::io::IOException("ctrtool::writeStreamToStream()", "Failed to read from source streeam.");
+		}
+
+		out_stream->write(cache.data(), cache_read_len);
+
+		remaining_data -= int64_t(cache_read_len);
+	}
+}
+
+void ctrtool::writeStreamToStream(const std::shared_ptr<tc::io::IStream>& in_stream, const std::shared_ptr<tc::io::IStream>& out_stream, size_t cache_size)
+{
+	tc::ByteData cache = tc::ByteData(cache_size);
+	writeStreamToStream(in_stream, out_stream, cache);
+}

--- a/ctrtool/src/util.h
+++ b/ctrtool/src/util.h
@@ -1,0 +1,15 @@
+#pragma once
+#include "types.h"
+#include <tc/io.h>
+
+namespace ctrtool
+{
+
+void writeSubStreamToFile(const std::shared_ptr<tc::io::IStream>& in_stream, int64_t offset, int64_t length, const tc::io::Path& out_path, tc::ByteData& cache);
+void writeSubStreamToFile(const std::shared_ptr<tc::io::IStream>& in_stream, int64_t offset, int64_t length, const tc::io::Path& out_path, size_t cache_size = 0x10000);
+void writeStreamToFile(const std::shared_ptr<tc::io::IStream>& in_stream, const tc::io::Path& out_path, tc::ByteData& cache);
+void writeStreamToFile(const std::shared_ptr<tc::io::IStream>& in_stream, const tc::io::Path& out_path, size_t cache_size = 0x10000);
+void writeStreamToStream(const std::shared_ptr<tc::io::IStream>& in_stream, const std::shared_ptr<tc::io::IStream>& out_stream, tc::ByteData& cache);
+void writeStreamToStream(const std::shared_ptr<tc::io::IStream>& in_stream, const std::shared_ptr<tc::io::IStream>& out_stream, size_t cache_size = 0x10000);
+
+}

--- a/ctrtool/src/version.h
+++ b/ctrtool/src/version.h
@@ -3,5 +3,5 @@
 #define BIN_NAME	"ctrtool"
 #define VER_MAJOR	1
 #define VER_MINOR	1
-#define VER_PATCH	0
+#define VER_PATCH	1
 #define AUTHORS		"jakcron"


### PR DESCRIPTION
# About
CTRTool has a flag that forces processing files as unencrypted, the plain flag (`-p`/`--plain`). However this is only implemented for NCCH encryption. This pull request implements this mode when processing for the content encryption layer for CIA files.

# Changes
* Honour plain flag when processing CIA content encryption.
* Bump CTRTool version to `v1.1.1`.
