### PR TITLE
Update for 9.6 CCI changes

### DIFF
--- a/ctrtool/deps/libnintendo-n3ds/include/ntd/n3ds/cci.h
+++ b/ctrtool/deps/libnintendo-n3ds/include/ntd/n3ds/cci.h
@@ -79,10 +79,20 @@ struct NcsdCommonHeader
 
 	struct GameCardExtendedHeader
 	{
+		struct CryptoType
+		{
+			byte_t enabled : 1;
+			byte_t value : 2;
+			byte_t reserved : 5;
+		};
+
 		// 0x90
 		std::array<tc::bn::le64<uint64_t>, kPartitionNum> partition_id;
 		// 0xD0
-		tc::bn::pad<0x30>                                 reserved;
+		tc::bn::pad<0x2E>                                 reserved;
+		// 0xFE
+		CryptoType                                        crypto_type;
+		byte_t                                            backup_security_version;
 	};
 
 	struct NandExtendedHeader

--- a/ctrtool/src/CciProcess.cpp
+++ b/ctrtool/src/CciProcess.cpp
@@ -22,6 +22,7 @@ ctrtool::CciProcess::CciProcess() :
 	mUsedImageSize(0),
 	mValidSignature(ValidState::Unchecked),
 	mValidInitialDataMac(ValidState::Unchecked),
+	mValidCryptoType(ValidState::Unchecked),
 	mDecryptedTitleKey(),
 	mNcchProcess(),
 	mFsReader()
@@ -234,6 +235,25 @@ void ctrtool::CciProcess::importHeader()
 		fmt::print(stderr, "[{} ERROR] Failed to determine key to decrypt InitialData.\n", mModuleLabel);
 	}
 
+	// verify crypto type
+	if (mVerify)
+	{
+		// only verify if the enabled bit is set
+		if (mHeader.ncsd_header.card_ext.crypto_type.enabled)
+		{
+			mValidCryptoType = mHeader.ncsd_header.card_ext.crypto_type.value == mHeader.card_info.flag.crypto_type ? ValidState::Good : ValidState::Fail;
+		}
+		else
+		{
+			mValidCryptoType = ValidState::Good;
+		}
+
+		if (mValidCryptoType != ValidState::Good)
+		{
+			fmt::print(stderr, "[{} ERROR] CryptoType was invalid.\n", mModuleLabel);
+		}
+	}
+
 	// open fs reader
 	mFsReader = std::shared_ptr<tc::io::VirtualFileSystem>(new tc::io::VirtualFileSystem(ntd::n3ds::CciFsShapshotGenerator(mInputStream)));
 }
@@ -294,7 +314,7 @@ void ctrtool::CciProcess::printHeader()
 	}
 	fmt::print(" Flags:                  {}\n", tc::cli::FormatUtil::formatBytesAsString(mHeader.ncsd_header.flags.data(), mHeader.ncsd_header.flags.size(), true, ""));
 	fmt::print("  BackupWriteWaitTime:   {:02x}\n", (uint32_t)mHeader.ncsd_header.flags[mHeader.NcsdFlagIndex_BackupWriteWaitTime]);
-	fmt::print("  BackupSecurityVersion: {:02x}\n", (uint32_t)mHeader.ncsd_header.flags[mHeader.NcsdFlagIndex_BackupSecurityVersion]);
+	fmt::print("  BackupSecurityVersion: {:02x}\n", (uint32_t)mHeader.ncsd_header.flags[mHeader.NcsdFlagIndex_BackupSecurityVersion] + mHeader.ncsd_header.card_ext.backup_security_version);
 	fmt::print("  CardInfo:              {:02x}\n", (uint32_t)mHeader.ncsd_header.flags[mHeader.NcsdFlagIndex_CardInfo]);
 	byte_t card_device = (mHeader.ncsd_header.flags[mHeader.NcsdFlagIndex_CardDevice] | mHeader.ncsd_header.flags[mHeader.NcsdFlagIndex_CardDevice_Deprecated]);
 	fmt::print("  CardDevice:            {:02x} ({})\n", (uint32_t)card_device, getCardDeviceString(card_device));
@@ -314,7 +334,7 @@ void ctrtool::CciProcess::printHeader()
 	fmt::print("CardInfo:\n");
 	fmt::print(" WriteableRegion:        0x{:08X}\n", mHeader.card_info.writable_region.unwrap());
 	fmt::print(" CardType:               {} ({:X})\n", getCardTypeString(mHeader.card_info.flag.card_type), (uint32_t)mHeader.card_info.flag.card_type);
-	fmt::print(" CryptoType:             {} ({:X})\n", getCryptoTypeString(mHeader.card_info.flag.crypto_type), (uint32_t)mHeader.card_info.flag.crypto_type);
+	fmt::print(" CryptoType: {:6}      {} ({:X})\n", getValidString(mValidCryptoType), getCryptoTypeString(mHeader.card_info.flag.crypto_type), (uint32_t)mHeader.card_info.flag.crypto_type);
 	
 	// mastering metadata
 	fmt::print("MasteringMetadata:\n");

--- a/ctrtool/src/CciProcess.cpp
+++ b/ctrtool/src/CciProcess.cpp
@@ -243,7 +243,8 @@ void ctrtool::CciProcess::importHeader()
 		{
 			mValidCryptoType = mHeader.card_info.flag.crypto_type == mHeader.ncsd_header.card_ext.crypto_type.value ? ValidState::Good : ValidState::Fail;
 
-			if (mValidCryptoType != ValidState::Good) {
+			if (mValidCryptoType != ValidState::Good)
+			{
 				fmt::print(stderr, "[{} ERROR] CryptoType was invalid.\n", mModuleLabel);
 			}
 		}

--- a/ctrtool/src/CciProcess.cpp
+++ b/ctrtool/src/CciProcess.cpp
@@ -241,16 +241,11 @@ void ctrtool::CciProcess::importHeader()
 		// only verify if the enabled bit is set
 		if (mHeader.ncsd_header.card_ext.crypto_type.enabled)
 		{
-			mValidCryptoType = mHeader.ncsd_header.card_ext.crypto_type.value == mHeader.card_info.flag.crypto_type ? ValidState::Good : ValidState::Fail;
-		}
-		else
-		{
-			mValidCryptoType = ValidState::Good;
-		}
+			mValidCryptoType = mHeader.card_info.flag.crypto_type == mHeader.ncsd_header.card_ext.crypto_type.value ? ValidState::Good : ValidState::Fail;
 
-		if (mValidCryptoType != ValidState::Good)
-		{
-			fmt::print(stderr, "[{} ERROR] CryptoType was invalid.\n", mModuleLabel);
+			if (mValidCryptoType != ValidState::Good) {
+				fmt::print(stderr, "[{} ERROR] CryptoType was invalid.\n", mModuleLabel);
+			}
 		}
 	}
 

--- a/ctrtool/src/CciProcess.h
+++ b/ctrtool/src/CciProcess.h
@@ -43,6 +43,7 @@ private:
 	int64_t mUsedImageSize;
 	byte_t mValidSignature;
 	byte_t mValidInitialDataMac;
+	byte_t mValidCryptoType;
 	ntd::n3ds::CciHeader mHeader;
 	tc::Optional<KeyBag::Aes128Key> mDecryptedTitleKey;
 	ctrtool::NcchProcess mNcchProcess;


### PR DESCRIPTION
This pull request implements the changes that were made in 9.6 to the CCI format, as mentioned on the 3dbrew NCSD page. These changes include:
- A field that is used to validate the cardbus encryption type found within the CardInfo region.
  - This was most likely implemented by Nintendo as protection against the Sky3DS flash card. Without this validation, any game cards that used the new cardbus encryption keys (1 and 2) could be dumped and modified to instead use the old cardbus encryption key (0), thus providing no additional security.
- A second field for the backup security version.
  - Yeah, I've got nothing for this one. The original field was already being verified as it was under the NCSD header RSA-2048 signature.