### PR TITLE
Remove incorrect ExeFS header hash validation.

### DIFF
--- a/ctrtool/deps/libnintendo-n3ds/src/ExeFsSnapshotGenerator.cpp
+++ b/ctrtool/deps/libnintendo-n3ds/src/ExeFsSnapshotGenerator.cpp
@@ -33,7 +33,7 @@ ntd::n3ds::ExeFsSnapshotGenerator::ExeFsSnapshotGenerator(const std::shared_ptr<
 	stream->seek(0, tc::io::SeekOrigin::Begin);
 	stream->read((byte_t*)(&hdr), sizeof(ntd::n3ds::ExeFsHeader));
 
-	if (hdr.file_table[0].name[0] == 0 || hdr.file_table[0].offset.unwrap() != 0 || hdr.hash_table[ntd::n3ds::ExeFsHeader::kFileNum - 1][0] == 0)
+	if (hdr.file_table[0].name[0] == 0 || hdr.file_table[0].offset.unwrap() != 0)
 	{
 		throw tc::ArgumentOutOfRangeException("ntd::n3ds::ExeFsSnapshotGenerator", "ExeFsHeader is corrupted (Bad first entry).");
 	}

--- a/ctrtool/src/ExeFsProcess.cpp
+++ b/ctrtool/src/ExeFsProcess.cpp
@@ -94,7 +94,7 @@ void ctrtool::ExeFsProcess::importHeader()
 	mInputStream->read((byte_t*)&mHeader, sizeof(ntd::n3ds::ExeFsHeader));
 
 	// do some simple checks to verify if this is an EXEFS header
-	if (mHeader.file_table[0].name[0] == 0 || mHeader.file_table[0].offset.unwrap() != 0 || mHeader.hash_table[ntd::n3ds::ExeFsHeader::kFileNum - 1][0] == 0)
+	if (mHeader.file_table[0].name[0] == 0 || mHeader.file_table[0].offset.unwrap() != 0)
 	{
 		throw tc::ArgumentOutOfRangeException(mModuleLabel, "ExeFsHeader is corrupted (Bad first entry).");
 	}

--- a/ctrtool/src/NcchProcess.cpp
+++ b/ctrtool/src/NcchProcess.cpp
@@ -489,8 +489,7 @@ void ctrtool::NcchProcess::determineRegionEncryption()
 
 					// quick header validation
 					if (exefs_hdr.file_table[0].name[0] == 0 ||
-					    exefs_hdr.file_table[0].offset.unwrap() != 0 ||
-					    exefs_hdr.getFileHash(0)->operator[](0) == 0)
+					    exefs_hdr.file_table[0].offset.unwrap() != 0)
 					{
 						throw tc::ArgumentOutOfRangeException(mModuleLabel, "ExeFsHeader is corrupted (Bad first entry).");
 					}


### PR DESCRIPTION
One of the checks ctrtool currently performs to test if an ExeFS header is valid is to check if the first byte of the first file hash is not 0. However this causes validation to fail on a valid ExeFS where the hash of the first file happens to actually start with a 0 byte.

Removing this check allows the files I tested with to be parsed. They then pass all signature and hash checks, confirming their validity.