### PR TITLE
Address #142, makerom no longer strictly requires ELFs to have a data segment

### DIFF
--- a/makerom/src/code.c
+++ b/makerom/src/code.c
@@ -168,10 +168,6 @@ int CreateExeFsCode(elf_context *elf, ncch_settings *set)
 
 	/* Checking the existence of essential ELF Segments */
 	if (!text.fileSize) return NOT_FIND_TEXT_SEGMENT;
-	if (!rwdata.fileSize) return NOT_FIND_DATA_SEGMENT;
-
-	/* Calculating BSS size */
-	set->codeDetails.bssSize = rwdata.memSize - rwdata.fileSize;
 
 	/* Allocating Buffer for ExeFs Code */
 	bool noCodePadding = set->options.noCodePadding;
@@ -209,7 +205,7 @@ int CreateExeFsCode(elf_context *elf, ncch_settings *set)
 		set->exefsSections.code.buffer = code;
 	}
 
-	/* Setting code_segment data and freeing original buffers */
+	/* Setting code_segment data */
 	set->codeDetails.textAddress = text.address;
 	set->codeDetails.textMaxPages = text.pageNum;
 	set->codeDetails.textSize = text.fileSize;
@@ -221,6 +217,14 @@ int CreateExeFsCode(elf_context *elf, ncch_settings *set)
 	set->codeDetails.rwAddress = rwdata.address;
 	set->codeDetails.rwMaxPages = rwdata.pageNum;
 	set->codeDetails.rwSize = rwdata.fileSize;
+
+	/* Calculating BSS size */
+	if (rwdata.fileSize) {
+		set->codeDetails.bssSize = rwdata.memSize - rwdata.fileSize;
+	}
+	else {
+		set->codeDetails.bssSize = 0;
+	}
 
 	if (set->rsfSet->SystemControlInfo.StackSize)
 		set->codeDetails.stackSize = strtoul(set->rsfSet->SystemControlInfo.StackSize, NULL, 0);


### PR DESCRIPTION
# About
This is in response to #142 where @kynex7510 reported that makerom was unable to use ELFs that only had a text segment. This is relevant to https://github.com/hax0kartik/3ds_pdn which is an open source implementation of the PDN module. That project has a work around to create a dummy data segment, just so makerom will process it. Ultimately such a workaround shouldn't be needed.

# Changes
Very minimal, just changes the logic in `code.c` to safely tolerate ELF files with no data segment.